### PR TITLE
Change curve label, average over 7 days by default, use central averages

### DIFF
--- a/dashboard-functions.js
+++ b/dashboard-functions.js
@@ -327,7 +327,8 @@ function diamondPrincessEstimateRatio(countryName)
 function smoothenData(d)
 {
     var n = parseFloat(document.getElementById("smoothenDays").value);
-
+    var offset = Math.floor(n/2);
+    
     var result = [];
 
     // backward box filter
@@ -336,8 +337,10 @@ function smoothenData(d)
         var s = 0.0;
 
         for (var j = 0; j < n; j ++) {
-            var k = i - j;
+            var k = i + offset - j;
             if (k < 0)
+                continue;
+            if (k >= d.length)
                 continue;
 
             if (d[k] == null)

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
         Smoother Parameters:
         <div>
           <label for="smoothenDays">Period [Days]:<!-- TODO: explainer --></label>
-          <input type="range" min="3" max="40" value="8" class="range" id="smoothenDays" oninput="updateControlInfos()"  onchange="recalculateCurvesAndPlot()">
+          <input type="range" min="3" max="40" value="7" class="range" id="smoothenDays" oninput="updateControlInfos()"  onchange="recalculateCurvesAndPlot()">
           <div class="rangeInfo" id="smoothenDaysInfo">Unset</div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
           <option value="D">Total Reported Deaths</option>
           <option value="d">New Reported Deaths</option>
           <option value="P">"Diamond Princess Estimate"</option>
-          <option value="p">"Diamond Princess Estimate" to Total Reported Cases</option>
+          <option value="p">"Diamond Princess Estimate" to Reported Cases</option>
         </select>
       </div>
 


### PR DESCRIPTION
the central average prevents the smoothened results trailing the raw ones, but on the flip side, the results of the last day will change once data for the next few days becomes available.

Further I don't really get why averaging over 7 days seems to yield better results than for 8 (because including the same day from a week before should not make things worse), but it does so let's change the default...