### PR TITLE
change the "Diamond Princess Estimate" to using new instead of cases

### DIFF
--- a/dashboard-functions.js
+++ b/dashboard-functions.js
@@ -288,15 +288,15 @@ function diamondPrincessEstimate(countryName)
     // assumption is that new cases are reported 7 days after
     // infection and if they end deadly, death will occur 21 days
     // after infection.
-    for (var i = 13; i < inputData[countryName].totalDeaths.length; i++) {
-        if (countryData.totalDeaths[i])
-            result.push(countryData.totalDeaths[i] / (13./712));
+    for (var i = 13; i < inputData[countryName].newDeaths.length; i++) {
+        if (countryData.newDeaths[i])
+            result.push(countryData.newDeaths[i] / (13./712));
         else
             result.push(null);
     }
 
-    for (var i = Math.max(0, inputData[countryName].totalDeaths.length - 14);
-         i < inputData[countryName].totalDeaths.length;
+    for (var i = Math.max(0, inputData[countryName].newDeaths.length - 14);
+         i < inputData[countryName].newDeaths.length;
          i++) {
         result.push(null);
     }
@@ -312,8 +312,8 @@ function diamondPrincessEstimateRatio(countryName)
     
     for (var i = 0; i < countryData.totalCases.length; i++) {
         if (dpe[i]) {
-            if (countryData.totalCases[i])
-                result.push(dpe[i]/countryData.totalCases[i]);
+            if (countryData.newCases[i])
+                result.push(dpe[i]/countryData.newCases[i]);
             else
                 result.push(null);
         }
@@ -335,8 +335,9 @@ function smoothenData(d)
     for (var i = 0; i < d.length; i ++) {
         var numValues = 0;
         var s = 0.0;
+        var lastK = -1;
 
-        for (var j = 0; j < n; j ++) {
+        for (var j = n - 1; j >= 0; j --) {
             var k = i + offset - j;
             if (k < 0)
                 continue;
@@ -346,11 +347,17 @@ function smoothenData(d)
             if (d[k] == null)
                 continue;
 
+            lastK = k;
             s += d[k];
             numValues += 1;
         }
 
-        if (numValues > 0)
+        if (lastK < i)
+            // do not extrapolate via the "back door". this assumes
+            // that the data point in question is part of the box
+            // filter...
+            result.push(null);
+        else if (numValues > 0)
             result.push(s/numValues);
         else
             result.push(null);

--- a/index.html
+++ b/index.html
@@ -37,8 +37,8 @@
           <option value="c">New Reported Cases</option>
           <option value="D">Total Reported Deaths</option>
           <option value="d">New Reported Deaths</option>
-          <option value="P">"Diamond Princess Estimate"</option>
-          <option value="p">"Diamond Princess Estimate" to Reported Cases</option>
+          <option value="P">New Cases, "Diamond Princess Estimate"</option>
+          <option value="p">"Diamond Princess Estimate" to Reported New Cases</option>
         </select>
       </div>
 


### PR DESCRIPTION
the intention is to give an rough indication of how well a country's testing and reporting regime is currently working assuming that the number of fatalities are correctly reported. (Using the total rate would yield an indicator for how well the country did overall so far.)

also, the smoother is improved to not extrapolate data so easily anymore. (this lead to spurious oscillations for the last few days of the smoothened DPE where there is no actual data available yet.)