### PR TITLE
web ui: use a crystal ball for the last few days of the prediction

### DIFF
--- a/dashboard-functions.js
+++ b/dashboard-functions.js
@@ -274,6 +274,26 @@ function estimateR(countryName) {
         }
     }
 
+    // for the last few days we need to improvise a bit: cases that
+    // will only be reported in the next few days will have a
+    // (typically relatively small) impact on the day which for which
+    // we ought to estimate the R factor. The problem is that for the
+    // newest data points, we do not know the number of cases for the
+    // next few days yet. Let's just take the average of the last week
+    // for this reason...
+    var lastWeekAverageCases = 0;
+    var n = Math.min(countryData.newCases.length, 7);
+    for (var i = countryData.newCases.length - n; i < countryData.newCases.length; ++i)
+        lastWeekAverageCases += countryData.newCases[i];
+    lastWeekAverageCases /= n;
+
+    // keep in mind that the injectivy offset is negative!
+    for (var dayIdx = result.length + infectivityOffset + 1; dayIdx < result.length; ++dayIdx) {
+        for (var i = 0; i < -infectivityOffset - (result.length - dayIdx) + 1; ++i) {
+            result[dayIdx] += lastWeekAverageCases*infectivityWeights[i];
+        }
+    }
+
     // compute the estimated R factor by dividing the actually seen
     // cases of a day by the attributable weight (currently in the
     // result array)


### PR DESCRIPTION
the problem is that the cases reported in the immediate future have an effect on the present. since the immediate future for the last few reported dates is not yet known, we take the average number of new cases of the last week where data is available and extrapolate with that. if the number of new cases reported in the next few days are close to the number used for the extrapolation, the results for the last few days should not change as much as they do before this patch.

The effect of this does not seem to be very dramatic, though.